### PR TITLE
Fixed build on arm macOS

### DIFF
--- a/src/vk/header/local.h
+++ b/src/vk/header/local.h
@@ -24,8 +24,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <math.h>
 #include <stdio.h>
 
+#if defined(__APPLE__)
+#include <SDL.h>
+#include <SDL_vulkan.h>
+#else
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_vulkan.h>
+#endif
 
 
 #include "../../common/header/ref_shared.h"


### PR DESCRIPTION
Clang was crashing when compiling `stb.c` on an M1 Mac - this PR allows the library to compile successfully