### PR TITLE
MoltenVK/macOs specific variables.

### DIFF
--- a/src/vk/header/local.h
+++ b/src/vk/header/local.h
@@ -37,6 +37,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include "../volk/volk.h"
 #include "qvk.h"
 
+#if defined(__APPLE__)
+#include <MoltenVK/vk_mvk_moltenvk.h>
+#include <dlfcn.h>
+#endif
+
 // verify if VkResult is VK_SUCCESS
 #define VK_VERIFY(x) { \
 	VkResult res = (x); \
@@ -144,6 +149,10 @@ extern	cvar_t	*vk_lmaptexturemode;
 extern	cvar_t	*vk_aniso;
 extern	cvar_t	*vk_sampleshading;
 extern	cvar_t	*vk_device_idx;
+#if defined(__APPLE__)
+extern  cvar_t  *vk_molten_fastmath;
+extern  cvar_t  *vk_molten_metalbuffers;
+#endif
 extern	cvar_t	*r_retexturing;
 extern	cvar_t	*r_scale8bittextures;
 extern	cvar_t	*r_nolerp_list;

--- a/src/vk/vk_rmain.c
+++ b/src/vk/vk_rmain.c
@@ -100,6 +100,10 @@ cvar_t	*vk_picmip;
 cvar_t	*vk_skymip;
 cvar_t	*vk_flashblend;
 cvar_t	*vk_finish;
+#if defined(__APPLE__)
+cvar_t  *vk_molten_fastmath;
+cvar_t  *vk_molten_metalbuffers;
+#endif
 cvar_t	*r_clear;
 cvar_t	*r_lockpvs;
 static cvar_t	*vk_polyblend;
@@ -1190,6 +1194,10 @@ R_Register( void )
 	vk_mip_nearfilter = ri.Cvar_Get("vk_mip_nearfilter", "0", CVAR_ARCHIVE);
 	vk_sampleshading = ri.Cvar_Get("vk_sampleshading", "1", CVAR_ARCHIVE);
 	vk_device_idx = ri.Cvar_Get("vk_device", "-1", CVAR_ARCHIVE);
+#if defined(__APPLE__)
+	vk_molten_fastmath = ri.Cvar_Get("vk_molten_fastmath", "0", CVAR_ARCHIVE);
+	vk_molten_metalbuffers = ri.Cvar_Get("vk_molten_metalbuffer", "0", CVAR_ARCHIVE);
+#endif
 	r_retexturing = ri.Cvar_Get("r_retexturing", "1", CVAR_ARCHIVE);
 	r_scale8bittextures = ri.Cvar_Get("r_scale8bittextures", "0", CVAR_ARCHIVE);
 	vk_underwater = ri.Cvar_Get("vk_underwater", "1", CVAR_ARCHIVE);


### PR DESCRIPTION
- vk_molten_metalbuffers: enable/disable Metal buffers to bind textures
more efficiently (>= Big Sur).
- vk_molten_fastmath: enable/disable float point op optimisations.