### PR TITLE
Vk_LoadPic fix unitialized var.

### DIFF
--- a/src/vk/vk_image.c
+++ b/src/vk/vk_image.c
@@ -1135,6 +1135,7 @@ Vk_LoadPic(const char *name, byte *pic, int width, int realwidth,
 	image->registration_sequence = registration_sequence;
 	// zero-clear Vulkan texture handle
 	QVVKTEXTURE_CLEAR(image->vk_texture);
+	texBuffer = 0;
 	image->width = realwidth;
 	image->height = realheight;
 	image->type = type;

--- a/src/vk/vk_rsurf.c
+++ b/src/vk/vk_rsurf.c
@@ -980,7 +980,7 @@ cluster
 void R_MarkLeaves (void)
 {
 	const byte	*vis;
-	byte	fatvis[MAX_MAP_LEAFS/8];
+	YQ2_ALIGNAS_TYPE(int) byte fatvis[MAX_MAP_LEAFS/8];
 	mnode_t	*node;
 	int		i;
 	mleaf_t	*leaf;


### PR DESCRIPTION
R_MarkLeaves data alignment to int when merging PVS clusters like GL renderers.