### PR TITLE
vk: size descriptor pool for all sampler consumers

### DIFF
--- a/src/vk/vk_common.c
+++ b/src/vk/vk_common.c
@@ -981,7 +981,7 @@ CreateDescriptorPool(void)
 		// sampler
 		{
 			.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
-			.descriptorCount = MAX_VKTEXTURES + 1
+			.descriptorCount = MAX_VKTEXTURES + MAX_LIGHTMAPS * 2 + 3
 		}
 	};
 
@@ -989,7 +989,7 @@ CreateDescriptorPool(void)
 		.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
 		.pNext = NULL,
 		.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
-		.maxSets = MAX_VKTEXTURES + 32,
+		.maxSets = poolSizes[1].descriptorCount + 16 + 8,
 		.poolSizeCount = sizeof(poolSizes) / sizeof(poolSizes[0]),
 		.pPoolSizes = poolSizes,
 	};


### PR DESCRIPTION
The combined-image-sampler pool was sized MAX_VKTEXTURES + 1, ignoring the lightmap (MAX_LIGHTMAPS * 2), colorbuffer and raw-texture sets that draw from the same pool. On texture- and lightmap-heavy maps the peak demand exceeds the pool, so vkAllocateDescriptorSets in QVk_CreateTexture returns VK_ERROR_OUT_OF_POOL_MEMORY and the renderer aborts. Size both the sampler count and maxSets for the real worst case.

Reported in yquake2/yquake2#1323.